### PR TITLE
Add shared_session_scope_pickle for arbitrary object support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add `shared_session_scope_pickle` that uses `pickle` for de/serialization.
+Make fixture that does cleanup also save missing test (which is then an empty set). Should make no runtime in supported use cases.
 - Make fixture that does cleanup also save missing test (which is then an empty set). Should make no runtime in supported use cases.
 
 ## [0.4.0]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ def my_fixture():
     yield object_instance
 
 def test_custom_object(my_fixture):
-    assert my_fixture.value == 42
+    assert my_fixture.value == CustomObject(42)
 ```
 
 Alternatively, you can use the `serialize` and `deserialize` arguments with `shared_session_scope_json`:

--- a/README.md
+++ b/README.md
@@ -63,8 +63,28 @@ I'm also not entirely confident cleanup will work correctly in all cases.
 
 ### Non JSON serializable data
 
-The default store uses `json.dumps/json.loads` which cannot handle all objects. Instead of implementing a custom store for
-each fixture, you can use the `serialize` and `deserialize` arguments
+The default store uses `json.dumps/json.loads` which cannot handle all objects. For arbitrary objects, you can use `shared_session_scope_pickle` which uses Python's pickle module:
+
+<!--- doctest:pickle --->
+```python
+from pytest_shared_session_scope import shared_session_scope_pickle, SetupToken
+
+class CustomObject:
+    def __init__(self, value):
+        self.value = value
+
+@shared_session_scope_pickle()
+def my_fixture():
+    object_instance = yield
+    if object_instance is SetupToken.FIRST:
+        object_instance = CustomObject(42)
+    yield object_instance
+
+def test_custom_object(my_fixture):
+    assert my_fixture.value == 42
+```
+
+Alternatively, you can use the `serialize` and `deserialize` arguments with `shared_session_scope_json`:
 
 <!--- doctest:non-serializable --->
 ```python

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ def my_fixture():
     yield object_instance
 
 def test_custom_object(my_fixture):
-    assert my_fixture.value == CustomObject(42)
+    assert isinstance(my_fixture, CustomObject)
+    assert my_fixture.value == 42
 ```
 
 Alternatively, you can use the `serialize` and `deserialize` arguments with `shared_session_scope_json`:

--- a/src/pytest_shared_session_scope/__init__.py
+++ b/src/pytest_shared_session_scope/__init__.py
@@ -10,4 +10,5 @@ from pytest_shared_session_scope.types import (
 from pytest_shared_session_scope.fixtures import (
     shared_session_scope_fixture as shared_session_scope_fixture,
     shared_session_scope_json as shared_session_scope_json,
+    shared_session_scope_pickle as shared_session_scope_pickle,
 )

--- a/src/pytest_shared_session_scope/fixtures.py
+++ b/src/pytest_shared_session_scope/fixtures.py
@@ -12,7 +12,7 @@ from typing_extensions import Generator
 import pytest
 
 from pytest_shared_session_scope._types import tests_started
-from pytest_shared_session_scope.store import FileStore, JsonStore
+from pytest_shared_session_scope.store import FileStore, JsonStore, PickleStore
 from pytest_shared_session_scope.types import CleanupToken, SetupToken, Store, StoreValueNotExists
 from xdist import is_xdist_worker
 
@@ -256,4 +256,51 @@ def shared_session_scope_json(
     """
     return shared_session_scope_fixture(
         JsonStore(), parse, serialize, deserialize, metadata_storage, **kwargs
+    )
+
+def shared_session_scope_pickle(
+    parse: Callable = _identity,
+    serialize: Callable = _identity,
+    deserialize: Callable = _identity,
+    metadata_storage: Store[str] = FileStore(),
+    **kwargs,
+):
+    """Create a session scope fixture that is shared among all workers using pickle storage.
+
+    Example:
+        ```python
+        from pytest_shared_session_scope import shared_session_scope_pickle, CleanupToken
+
+
+        class MyClass:
+            def __init__(self, value):
+                self.value = value
+
+        def expensive_calculation():
+            return MyClass(123)
+
+        @shared_session_scope_pickle()
+        def my_fixture():
+        initial = yield
+        if initial is None:
+            object_instance = expensive_calculation()
+        else:
+            object_instance = initial
+        token: CleanupToken = yield object_instance
+        if token is CleanupToken.last:
+            ... # Cleanup that should only happen once
+        ... # Do cleanup that should happend for all workers here
+
+        ```
+
+    Args:
+        parse: Function to parse the data before returning it to the test.
+        serialize: Function to serialize the data before saving it to the store.
+        deserialize: Function to deserialize the data after reading it from the store.
+        metadata_storage: Store to save metadata about the current test run.
+            This is necessary to determine which worker should do the cleanup.
+        **kwargs: Additional arguments to pass to the @pytest.fixture.
+    """
+    return shared_session_scope_fixture(
+        PickleStore(), parse, serialize, deserialize, metadata_storage, **kwargs
     )

--- a/src/pytest_shared_session_scope/fixtures.py
+++ b/src/pytest_shared_session_scope/fixtures.py
@@ -258,6 +258,7 @@ def shared_session_scope_json(
         JsonStore(), parse, serialize, deserialize, metadata_storage, **kwargs
     )
 
+
 def shared_session_scope_pickle(
     parse: Callable = _identity,
     serialize: Callable = _identity,

--- a/src/pytest_shared_session_scope/store.py
+++ b/src/pytest_shared_session_scope/store.py
@@ -1,4 +1,5 @@
 """Stores for sharing data between pytest sessions."""
+
 import pickle
 from contextlib import contextmanager
 import json
@@ -56,6 +57,7 @@ class JsonStore(FileStore):
     def write(self, identifier: str, data: Any, fixture_values: dict[str, Any]):
         """Write data to a file as json using json.dumps."""
         super().write(identifier, json.dumps(data), fixture_values)
+
 
 class PickleStore(LocalFileStoreMixin):
     """Store that reads and writes binary data using the builtin pickle module."""

--- a/src/pytest_shared_session_scope/store.py
+++ b/src/pytest_shared_session_scope/store.py
@@ -1,5 +1,5 @@
 """Stores for sharing data between pytest sessions."""
-
+import pickle
 from contextlib import contextmanager
 import json
 from pathlib import Path
@@ -56,3 +56,21 @@ class JsonStore(FileStore):
     def write(self, identifier: str, data: Any, fixture_values: dict[str, Any]):
         """Write data to a file as json using json.dumps."""
         super().write(identifier, json.dumps(data), fixture_values)
+
+class PickleStore(LocalFileStoreMixin):
+    """Store that reads and writes binary data using the builtin pickle module."""
+
+    def read(self, identifier: str, fixture_values: dict[str, Any]) -> str:
+        """Read data from a file."""
+        path = self._get_path(identifier, fixture_values["tmp_path_factory"])
+        try:
+            with open(path, "rb") as f:
+                return pickle.load(f)
+        except FileNotFoundError:
+            raise StoreValueNotExists()
+
+    def write(self, identifier: str, data: str, fixture_values: dict[str, Any]):
+        """Write data to a file."""
+        path = self._get_path(identifier, fixture_values["tmp_path_factory"])
+        with open(path, "wb") as f:
+            pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,17 +38,17 @@ def fixture_with_return():
     return 1
 
 
-class CustomObject:
+class CustomPickleObject:
     def __init__(self, value):
         self.value = value
-    
+
     def __eq__(self, other):
-        return isinstance(other, CustomObject) and self.value == other.value
+        return isinstance(other, CustomPickleObject) and self.value == other.value
 
 
 @shared_session_scope_pickle()
 def fixture_with_pickle():
     object_instance = yield
     if object_instance is SetupToken.FIRST:
-        object_instance = CustomObject(42)
+        object_instance = CustomPickleObject(42)
     yield object_instance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from pytest_shared_session_scope import shared_session_scope_json
+from pytest_shared_session_scope import shared_session_scope_json, shared_session_scope_pickle
 from datetime import datetime
 
 from pytest_shared_session_scope.types import CleanupToken, SetupToken
@@ -36,3 +36,19 @@ def fixture_with_deserializor():
 @shared_session_scope_json()
 def fixture_with_return():
     return 1
+
+
+class CustomObject:
+    def __init__(self, value):
+        self.value = value
+    
+    def __eq__(self, other):
+        return isinstance(other, CustomObject) and self.value == other.value
+
+
+@shared_session_scope_pickle()
+def fixture_with_pickle():
+    object_instance = yield
+    if object_instance is SetupToken.FIRST:
+        object_instance = CustomObject(42)
+    yield object_instance

--- a/tests/test_session_scope.py
+++ b/tests/test_session_scope.py
@@ -39,3 +39,7 @@ def test_fixture_with_return3(fixture_with_return):
 
 def test_fixture_with_serializtion(fixture_with_deserializor):
     assert isinstance(fixture_with_deserializor, datetime)
+
+
+def test_fixture_with_pickle(fixture_with_pickle):
+    assert fixture_with_pickle.value == 42

--- a/tests/test_session_scope.py
+++ b/tests/test_session_scope.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from tests.conftest import CustomPickleObject
+
 
 def test_fixture_with_cleanup(fixture_with_cleanup):
     assert fixture_with_cleanup == 1
@@ -42,4 +44,4 @@ def test_fixture_with_serializtion(fixture_with_deserializor):
 
 
 def test_fixture_with_pickle(fixture_with_pickle):
-    assert fixture_with_pickle.value == 42
+    assert fixture_with_pickle == CustomPickleObject(42)


### PR DESCRIPTION
Adds support for serializing arbitrary Python objects by introducing `shared_session_scope_pickle` which uses pickle instead of JSON. This eliminates the need for custom serialization functions when working with non-JSON serializable objects like class instances.

The implementation adds a new `PickleStore` class and convenience function, with updated documentation positioning pickle as the preferred option for arbitrary objects.